### PR TITLE
Replace terminal-style UI with minimalist quote page and refactor styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,64 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="author" content="TuJo">
-  <!-- Theme‑Color jetzt passend zum Terminal‑Grün -->
-  <meta name="theme-color" content="#00ff00">
-  <meta name="robots" content="noindex, nofollow">
-
-  <!-- Open Graph Meta Tags -->
-  <meta property="og:title" content="TuJo @ Web">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://tujo.is-cool.dev/">
-  <meta property="og:image" content="https://tujo.is-cool.dev/images/avatar.jpeg">
-  <meta property="og:description" content="TuJo @ Web">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
-  <!-- Twitter Card Meta Tags -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="TuJo @ web">
-  <meta name="twitter:description" content="TuJo's Github page">
-
-  <!-- Favicon and Icons -->
-  <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96">
-  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
-  <link rel="shortcut icon" href="/icons/favicon.ico">
-  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
-  <meta name="apple-mobile-web-app-title" content="TuJo">
-  <link rel="manifest" href="/icons/site.webmanifest">
-
-  <title>TuJo @ Web</title>
+  <meta name="theme-color" content="#000000">
+  <title>TuJo</title>
   <link rel="stylesheet" href="styles/styles.css">
 </head>
 <body>
-  <div class="terminal">
-    <div class="line"><span class="prompt">tujo@web:~$</span> whoami</div>
-    <div class="output">TuJo</div>
-
-    <div class="line"><span class="prompt">tujo@web:~$</span> about</div>
-    <div class="output">My Github page.</div>
-
-    <div class="line"><span class="prompt">tujo@web:~$</span> links</div>
-    <div class="output">
-      <a href="https://github.com/tujo" target="_blank">GitHub</a>
+  <main class="page" aria-live="polite">
+    <div class="quote-wrap">
+      <p class="quote" id="quote">Loading quote…</p>
+      <p class="author" id="author"></p>
     </div>
+  </main>
 
-    <div class="line"><span class="prompt">tujo@web:~$</span> contact</div>
-    <div class="output">
-      <a href="mailto:hello@tujo.is-cool.dev">hello@tujo.is-cool.dev</a>
-    </div>
+  <footer class="footer">
+    <p>
+      Open Source Notice:
+      <a href="https://github.com/its-tujo/its-tujo.github.io" target="_blank" rel="noopener">View the source on GitHub</a>
+    </p>
+  </footer>
 
-    <div class="line"><span class="prompt">tujo@web:~$</span> cat source</div>
-    <div class="output">
-      <a href="https://github.com/its-tujo/its-tujo.github.io" target="_blank" rel="noopener">This website is open source</a>
-    </div>
+  <script>
+    const quotes = [
+      { text: 'Simplicity is the ultimate sophistication.', author: 'Leonardo da Vinci' },
+      { text: 'Less, but better.', author: 'Dieter Rams' },
+      { text: 'Perfection is achieved when there is nothing left to take away.', author: 'Antoine de Saint-Exupéry' },
+      { text: 'The quieter you become, the more you can hear.', author: 'Ram Dass' },
+      { text: 'Minimal design is maximum intention.', author: 'Unknown' }
+    ];
 
-    <div class="line"><span class="prompt">tujo@web:~$</span> <span class="cursor"></span></div>
-  </div>
+    const quoteElement = document.getElementById('quote');
+    const authorElement = document.getElementById('author');
+    const selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
+
+    quoteElement.textContent = selectedQuote.text;
+    authorElement.textContent = `— ${selectedQuote.author}`;
+  </script>
 </body>
 </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,91 +1,64 @@
-/* Grundlegende Terminal-Optik */
-html, body {
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
   margin: 0;
-  padding: 0;
-  height: 100%;
+  min-height: 100%;
   background: #000000;
-  color: #00ff00;
-  font-family: 'Courier New', Courier, 'Fira Code', Monaco, Consolas, monospace;
-  font-size: 1.2rem;
-  line-height: 1.5;
-  overflow-y: auto;
+  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
 body {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   min-height: 100vh;
-  padding: 1rem;
+  display: grid;
+  grid-template-rows: 1fr auto;
 }
 
-/* Terminal-Fenster mit Rahmen und sanftem Leuchten */
-.terminal {
-  width: 100%;
-  max-width: 780px;
-  background: #0a0a0a;
-  border: 2px solid #00ff00;
-  border-radius: 8px;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
-  padding: 2rem 1.5rem;
+.page {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
 }
 
-/* Jede Zeile wie in der Konsole */
-.line {
-  margin-bottom: 0.5rem;
+.quote {
+  margin: 0;
+  max-width: 44rem;
+  text-align: center;
+  font-size: clamp(1.5rem, 3vw, 2.4rem);
+  line-height: 1.4;
+  color: #ffffff;
+}
+
+.footer {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: center;
+  padding: 1rem 1rem 1.4rem;
 }
 
-.prompt {
-  font-weight: bold;
-  color: #00ff00;
-  margin-right: 1rem;
-  white-space: nowrap;
+.footer p {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.8rem;
+  text-align: center;
 }
 
-.output {
-  margin-left: 2rem;
-  color: #a0ffa0;
-  width: 100%;
-  word-break: break-word;
+.footer a,
+.footer a:visited {
+  color: #ffffff;
 }
 
-/* Links: gepunktet unterstrichen – wird bei hover durchgezogen */
-a {
-  color: #00ff00;
-  text-decoration: none;
-  border-bottom: 1px dotted #00ff00;
+
+.quote-wrap {
+  max-width: 44rem;
+  text-align: center;
 }
 
-a:hover {
-  border-bottom: 1px solid #00ff00;
-}
-
-/* Klassischer Terminal-Cursor */
-.cursor {
-  display: inline-block;
-  width: 0.7em;
-  height: 1.2em;
-  background-color: #00ff00;
-  vertical-align: middle;
-  animation: blink 1s step-end infinite;
-}
-
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
-}
-
-/* Kleine Anpassung für Mobilgeräte */
-@media (max-width: 500px) {
-  .terminal {
-    padding: 1.5rem 1rem;
-  }
-  .prompt {
-    margin-right: 0.5rem;
-  }
-  .output {
-    margin-left: 1.5rem;
-  }
+.author {
+  margin: 0.9rem 0 0;
+  color: #d0d0d0;
+  font-size: clamp(0.9rem, 1.4vw, 1.05rem);
+  letter-spacing: 0.02em;
 }


### PR DESCRIPTION
### Motivation
- Simplify the homepage from a terminal-themed interface to a clean, minimalist landing with dynamic content.
- Move away from the green terminal aesthetic to a neutral, responsive layout and typography.

### Description
- Replaced the terminal HTML in `index.html` with a centered quote display (`<main class="page">`) and a footer linking to the GitHub source, and changed the document `title` to `TuJo`.
- Removed many Open Graph, Twitter, favicon, and author meta tags and set `theme-color` to `#000000`.
- Added an inline script that selects a random quote from a `quotes` array and injects it into `#quote` and `#author` on load.
- Rewrote `styles/styles.css` to use global `box-sizing`, responsive grid layout, modern system fonts, and new classes for `.page`, `.quote`, `.quote-wrap`, `.author`, and `.footer`, and removed the terminal-specific styles and cursor animation.

### Testing
- No automated tests were added or executed for these static HTML/CSS/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b159b32d90833282a44819a18fae29)